### PR TITLE
fix(smc_fresco): update deprecated method invocation

### DIFF
--- a/smc/smc_fresco.go
+++ b/smc/smc_fresco.go
@@ -113,7 +113,7 @@ func (s *frescoSession) Init(ctx context.Context, id string) error {
 	}
 	// Associate session id with context for whole session
 	md := metadata.Pairs("session-id", id)
-	ctx = metadata.NewContext(ctx, md)
+	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	s.ctx = ctx
 	s.id = id


### PR DESCRIPTION
In grpc/grpc-go commit 
https://github.com/grpc/grpc-go/commit/0c1d39df28cc4e0369b185df2b33b1094cd543fb
deprecated the method invocation of NewContext.
(Also see https://github.com/grpc/grpc-go/issues/1178)

This pull request updates the code to use the suggested replacement.